### PR TITLE
Some security improvements to the password reset feature

### DIFF
--- a/src/modules/auth/checkToken/controller.js
+++ b/src/modules/auth/checkToken/controller.js
@@ -1,9 +1,10 @@
 'use strict';
 
 let joi = require('joi');
+let crypto = require('crypto');
 
 let schema = joi.object().keys({
-    token: joi.string().required()
+    secret: joi.string().required()
 })
 
 
@@ -18,9 +19,10 @@ module.exports = function (db) {
             return res.boom.badRequest(validation.error);
         }
 
+        const token = crypto.createHash('sha256').update(req.body.secret).digest('hex');
         let rows = await req.transaction.db.UserSecrets.find({
             where: {
-                resetToken: req.body.token
+                resetToken: token
             }
         });
         if (rows == 1) {

--- a/src/modules/auth/getToken/controller.js
+++ b/src/modules/auth/getToken/controller.js
@@ -29,10 +29,8 @@ module.exports = function (db) {
         }
 
         // Generate new token (1 round of SHA-256 from a 128-bit random value)
-        // See : https://security.stackexchange.com/questions/213975
-        let value = await util.promisify(crypto.randomBytes)(128);
-        let secret = await util.promisify(crypto.randomBytes)(128);
-        let token = crypto.createHmac('sha256', secret).update(value).digest('hex');
+        let secret = await util.promisify(crypto.randomBytes)(16);
+        let token = crypto.createHash('sha256').update(secret).digest('hex');
 
         // Save it
         let secrets = await user.getSecrets()
@@ -49,7 +47,7 @@ module.exports = function (db) {
                 text:  `
                     Dear user,
 
-                    Here is your password reset link : http://ipsaone.space/login?resetToken='+token+'"
+                    Here is your password reset link: https://ipsaone.space/login?secret=${secret}
 
                     Cheers,
                     The IPSA ONE Team

--- a/src/modules/auth/resetPassword/controller.js
+++ b/src/modules/auth/resetPassword/controller.js
@@ -10,8 +10,8 @@ const path = require('path');
 const config = require(path.join(root, './src/config/config'));
 
 let schema = joi.object().keys({
-    token: joi.string().required(),
-    password: joi.string().min(6).required()
+    secret: joi.string().required(),
+    password: joi.string().min(6).max(72).required()
 })
 
 
@@ -26,11 +26,10 @@ module.exports = function (db) {
             return res.boom.badRequest(validation.error);
         }
 
-        // Find the corresponding UserSecret
-        let secret;
+        const token = crypto.createHash('sha256').update(req.body.secret).digest('hex');
         let rows = await req.transaction.db.UserSecrets.find({
             where: {
-                resetToken: req.body.token
+                resetToken: token
             }
         });
         if (rows == 1) {

--- a/src/modules/users/controllers/store.js
+++ b/src/modules/users/controllers/store.js
@@ -7,7 +7,7 @@ const util = require('util');
 const schema = joi.object().keys({
     username: joi.string().min(4).required(),
     email: joi.string().min(5).required(),
-    password: joi.string().min(6).required(),
+    password: joi.string().min(6).max(72).required(),
     sendEmail: joi.bool().optional()
 });
 


### PR DESCRIPTION
This addresses some issues in the password reset feature.

Currently, reset tokens are computed as a HMAC of a 1024-bit random value using a 1024-bit single-use random key, and are directly mailed to users.

* These parameters don't make sense for a HMAC function. It is likely that the original intent was to use 128 bits, not 128 bytes (as expected by the `crypto.randomBytes()` function).
* Still, the key is not used for verification, so a HMAC is not useful at all here. The output is equivalent to 128 random bits.
* Passwords are hashed with 10-rounds of the bcrypt function. However, tokens are not. If a SQL injection allows read access to the database, arbitrary accounts can be taken over by using the password recovery feature, defeating the whole point of having passwords stretched.

There are also some minor issues. The format string of the link doesn't look correct, mixing interpolation and addition, and the schema accepts passwords more than 72 bytes long in spite of the bcrypt function truncating them after that point.

This pull request addresses the issues above. Tokens sent to users are 128-bit secrets, and what is stored in the database is now a hash (a key is not required since the input is unpredictable) of these secrets.

Unaddressed here is the fact that `resetTokenDate` doesn't seem to be used at all, and tokens don't seem to be deleted after a password reset either. This is a serious issue, as a compromised email account would allow permanent account takeover.